### PR TITLE
UI/UX Improvements and minor fixes

### DIFF
--- a/chrome/src/background.js
+++ b/chrome/src/background.js
@@ -107,7 +107,7 @@ chrome.runtime.onMessage.addListener(async (data, sender, sendResponse) => {
       break;
     }
     case "open_extension": {
-      chrome.tabs.create({'url': `chrome://extensions/?id=${chrome.runtime.id}`});
+      chrome.tabs.create({ url: `chrome://extensions/?id=${chrome.runtime.id}` });
       break;
     }
     case "summarize_page": {
@@ -192,19 +192,17 @@ chrome.webRequest.onBeforeRequest.addListener(
 );
 
 // Set our session token if we have one saved from storage.
-function setup() {
-  chrome.storage.local.get("session_token", (sessionObj) => {
-    if (sessionObj && sessionObj.session_token) {
-      sessionToken = sessionObj.session_token;
-      updateRules();
-    }
-  });
+async function setup() {
+  const sessionObject = await chrome.storage.local.get('session_token');
+  if (sessionObject?.session_token) {
+    sessionToken = sessionObject.session_token;
+    updateRules();
+  }
 
-  chrome.storage.local.get("sync_existing", (syncObj) => {
-    if (syncObj && syncObj.sync_existing != undefined) {
-      syncSessionFromExisting = syncObj.sync_existing;
-    }
-  });
+  const syncObject = await chrome.storage.local.get('sync_existing');
+  if (typeof syncObject?.sync_existing !== 'undefined') {
+    syncSessionFromExisting = syncObject.sync_existing;
+  }
 }
 
 setup();

--- a/chrome/src/popup.js
+++ b/chrome/src/popup.js
@@ -85,9 +85,7 @@ async function setup() {
 
   eCopySummary.style.display = "none";
 
-  chrome.runtime.sendMessage({ type: "get_data" }, (response) => {
-    if (!response) return;
-
+  async function handleGetData(response) {
     if (response.token && eStatus) {
       eStatus.classList.remove('status_error');
       eStatus.classList.add('status_good');
@@ -117,7 +115,7 @@ async function setup() {
             const eChromeLink = document.querySelector("#chrome_link");
             if (eChromeLink) {
               eChromeLink.addEventListener("click", async () => {
-                chrome.runtime.sendMessage({type: "open_extension"}, (response) => {
+                chrome.runtime.sendMessage({ type: "open_extension" }, (response) => {
                   if (!response)
                     console.error('error opening extension: ', chrome.runtime.lastError.message);
                 });
@@ -126,7 +124,25 @@ async function setup() {
           }
         });
     }
-  });
+  }
+
+  try {
+    chrome.runtime.sendMessage({ type: "get_data" }, (response) => {
+      if (!response) return;
+
+      handleGetData(response);
+    });
+  } catch (error) {
+    // Sometimes the background/popup communication fails, but we can still get local info
+    const sessionObject = await chrome.storage.local.get('session_token');
+    const syncObject = await chrome.storage.local.get('sync_existing');
+
+    handleGetData({
+      token: sessionObject?.session_token,
+      sync_existing: typeof syncObject?.sync_existing !== 'undefined' ? syncObject : true,
+      browser: "chrome",
+    });
+  }
 
   const eSaveToken = document.querySelector("#token_save");
   if (!eSaveToken) {
@@ -160,9 +176,13 @@ async function setup() {
     if (eTokenDiv.style.display === '') {
       eAdvanced.innerHTML = 'Advanced settings';
       eTokenDiv.style.display = 'none';
+      eSummarize.style.display = '';
     } else {
       eAdvanced.innerHTML = 'Hide advanced settings';
       eTokenDiv.style.display = '';
+      eSummarize.style.display = 'none';
+      eSummaryResult.style.display = 'none';
+      eCopySummary.style.display = 'none';
     }
   });
 
@@ -180,7 +200,8 @@ async function setup() {
     }
 
     chrome.tabs.query({ active: true }, (tabs) => {
-      const tab = tabs[0];
+      // Chrome might give us more than one active tab when something like "chrome://*" is also open
+      const tab = tabs.find((tab) => tab.url.startsWith('http://') || tab.url.startsWith('https://')) || tabs[0];
 
       const { url } = tab;
 

--- a/firefox/src/background.js
+++ b/firefox/src/background.js
@@ -40,8 +40,11 @@ browser.runtime.onMessage.addListener(async (data) => {
       break;
     }
     case "open_extension": {
-        if (IS_CHROME)
-          chrome.tabs.create({'url': `chrome://extensions/?id=${chrome.runtime.id}`});
+        if (IS_CHROME) {
+          chrome.tabs.create({ url: `chrome://extensions/?id=${chrome.runtime.id}` });
+        } else {
+          chrome.tabs.create({ url: `addons://detail/${chrome.runtime.id}` });
+        }
       break;
     }
     case "summarize_page": {
@@ -53,6 +56,63 @@ browser.runtime.onMessage.addListener(async (data) => {
       break;
   }
 });
+
+async function summarizePage(token, url, summary_type, target_language) {
+  let summary = '';
+  let success = false;
+
+  try {
+    const requestParams = {
+      url,
+      summary_type,
+    };
+
+    if (target_language) {
+      requestParams.target_language = target_language;
+    }
+
+    const searchParams = new URLSearchParams(requestParams);
+
+    const response = await fetch(`https://kagi.com/mother/summary_labs?${searchParams.toString()}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `${token}`,
+      },
+      credentials: 'include',
+    });
+
+    if (response.status === 200) {
+      const result = await response.json();
+
+      console.debug('summarize response', result);
+
+      summary = result?.output_text || 'Unknown error';
+      success = Boolean(result) && !Boolean(result.error);
+    } else {
+      console.error('summarize error', response.status, response.statusText);
+
+      if (response.status === 401) {
+        summary = 'Invalid Token! Please set a new one.';
+      } else {
+        summary = `Error: ${response.status} - ${response.statusText}`;
+      }
+    }
+  } catch (error) {
+    summary = error.message ? `Error: ${error.message}` : JSON.stringify(error);
+  }
+
+  if (summary) {
+    chrome.runtime.sendMessage({
+      type: "summary_finished",
+      summary,
+      success,
+    }, (response) => {
+      if (!response)
+        console.error('error setting summary: ', chrome.runtime.lastError.message);
+    });
+  }
+}
 
 /*
  * Attempts to grab sessions from existing Kagi windows.
@@ -121,71 +181,15 @@ browser.webRequest.onBeforeRequest.addListener(
 
 // Set our session token if we have one saved from storage.
 async function setup() {
-  const sessionObj = await browser.storage.local.get("session_token");
-  if (sessionObj && sessionObj.session_token) {
-    sessionToken = sessionObj.session_token;
+  const sessionObject = await chrome.storage.local.get('session_token');
+  if (sessionObject?.session_token) {
+    sessionToken = sessionObject.session_token;
+    updateRules();
   }
 
-  const syncObj = await browser.storage.local.get("sync_existing");
-  if (syncObj && syncObj.sync_existing != undefined) {
-    syncSessionFromExisting = syncObj.sync_existing;
-  }
-}
-
-async function summarizePage(token, url, summary_type, target_language) {
-  let summary = '';
-  let success = false;
-
-  try {
-    const requestParams = {
-      url,
-      summary_type,
-    };
-
-    if (target_language) {
-      requestParams.target_language = target_language;
-    }
-
-    const searchParams = new URLSearchParams(requestParams);
-
-    const response = await fetch(`https://kagi.com/mother/summary_labs?${searchParams.toString()}`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `${token}`,
-      },
-      credentials: 'include',
-    });
-
-    if (response.status === 200) {
-      const result = await response.json();
-
-      console.debug('summarize response', result);
-
-      summary = result?.output_text || 'Unknown error';
-      success = Boolean(result) && !Boolean(result.error);
-    } else {
-      console.error('summarize error', response.status, response.statusText);
-
-      if (response.status === 401) {
-        summary = 'Invalid Token! Please set a new one.';
-      } else {
-        summary = `Error: ${response.status} - ${response.statusText}`;
-      }
-    }
-  } catch (error) {
-    summary = error.message ? `Error: ${error.message}` : JSON.stringify(error);
-  }
-
-  if (summary) {
-    chrome.runtime.sendMessage({
-      type: "summary_finished",
-      summary,
-      success,
-    }, (response) => {
-      if (!response)
-        console.error('error setting summary: ', chrome.runtime.lastError.message);
-    });
+  const syncObject = await chrome.storage.local.get('sync_existing');
+  if (typeof syncObject?.sync_existing !== 'undefined') {
+    syncSessionFromExisting = syncObject.sync_existing;
   }
 }
 


### PR DESCRIPTION
- Load session data even if the background process/communication fails
- When seeing "advanced settings", hide the summarize section
- Fixes a situation where you could get "invalid URL" if you had `chrome://extensions` open in addition to the tab you were trying to summarize
- Fix "chrome link" for Firefox
- Minor code changes for consistency across firefox/chrome

---

[kagi_chrome_0.3.zip](https://github.com/kagisearch/browser_extensions/files/11803234/kagi_chrome_0.3.zip)

[kagi_firefox_0.3.zip](https://github.com/kagisearch/browser_extensions/files/11803235/kagi_firefox_0.3.zip)
