### PR TITLE
Summarize: Add API Key option (with Engine choice)

### DIFF
--- a/chrome/src/background.js
+++ b/chrome/src/background.js
@@ -31,6 +31,7 @@ function saveToken({ token, api_token } = {}, isManual) {
   if (!shouldSync && sessionToken) {
     chrome.runtime.sendMessage({
       type: "synced",
+      token: sessionToken,
       api_token: sessionApiToken,
     }, (response) => {
       if (!response)

--- a/chrome/src/popup.css
+++ b/chrome/src/popup.css
@@ -125,10 +125,7 @@ h3 {
 .title {
   font-size: 0.875rem;
   font-weight: 700;
-}
-
-.setting_row .desc {
-  max-width: 80%;
+  padding-right: 0.75rem;
 }
 
 p {

--- a/chrome/src/popup.html
+++ b/chrome/src/popup.html
@@ -59,7 +59,7 @@
             </div>
             <div class="desc">
               You can paste the login url from the control center or the raw login token.
-              <br>
+              <br />
               <a href="https://kagi.com/faq#using-login-token" target="_blank">Learn more about login tokens</a>
             </div>
           </div>
@@ -70,7 +70,24 @@
         </div>
 
         <div class="setting_row">
-          <button id="token_save">Set Token</button>
+          <div>
+            <div class="title">
+              Universal Summarizer API key
+            </div>
+            <div class="desc">
+              This enables selection of advanced summarization models available with the <a href="https://kagi.com/summarizer/api.html" target="_blank">Universal Summarizer API</a>.
+              <br />
+              Note: You can still use summarize feature in Kagi extension without any API key, provided you are logged in into your Kagi account.
+            </div>
+          </div>
+        </div>
+
+        <div class="setting_row">
+          <input type="password" id="api_token_input" value="" placeholder="my API key"/>
+        </div>
+
+        <div class="setting_row">
+          <button id="token_save">Set Tokens</button>
         </div>
 
       </div>
@@ -123,6 +140,16 @@
               <option value="TR">Turkish</option>
               <option value="UK">Ukrainian</option>
               <option value="ZH">Chinese (simplified)</option>
+            </select>
+          </div>
+
+          <div class="api_param" style="display: none">
+            <label for="engine">Engine</label>
+            <select id="engine">
+              <option value="cecil" selected="selected">Cecil</option>
+              <option value="agnes">Agnes</option>
+              <option value="daphne">Daphne</option>
+              <option value="muriel">Muriel</option>
             </select>
           </div>
 

--- a/chrome/src/popup.html
+++ b/chrome/src/popup.html
@@ -86,8 +86,20 @@
           <input type="password" id="api_token_input" value="" placeholder="my API key"/>
         </div>
 
+        <div class="setting_row api_param" style="display: none">
+          <div>
+            <label class="title" for="engine">API Summarizer Engine</label>
+            <select id="engine">
+              <option value="cecil" selected="selected">Cecil</option>
+              <option value="agnes">Agnes</option>
+              <option value="daphne">Daphne</option>
+              <option value="muriel">Muriel</option>
+            </select>
+          </div>
+        </div>
+
         <div class="setting_row">
-          <button id="token_save">Set Tokens</button>
+          <button id="token_save">Save settings</button>
         </div>
 
       </div>
@@ -140,16 +152,6 @@
               <option value="TR">Turkish</option>
               <option value="UK">Ukrainian</option>
               <option value="ZH">Chinese (simplified)</option>
-            </select>
-          </div>
-
-          <div class="api_param" style="display: none">
-            <label for="engine">Engine</label>
-            <select id="engine">
-              <option value="cecil" selected="selected">Cecil</option>
-              <option value="agnes">Agnes</option>
-              <option value="daphne">Daphne</option>
-              <option value="muriel">Muriel</option>
             </select>
           </div>
 

--- a/chrome/src/popup.js
+++ b/chrome/src/popup.js
@@ -48,6 +48,18 @@ async function setup() {
 
   eTokenInput.addEventListener("click", () => this.value ? this.setSelectionRange(0, this.value.length) : null);
 
+  const eApiTokenInput = document.querySelector("#api_token_input");
+  if (!eApiTokenInput) {
+    console.error("Could not set API token because no input exists");
+    return;
+  }
+
+  eApiTokenInput.addEventListener("focus", (e) => {
+    e.target.select();
+  });
+
+  eApiTokenInput.addEventListener("click", () => this.value ? this.setSelectionRange(0, this.value.length) : null);
+
   const eStatus = document.querySelector("#status");
 
   const eAdvanced = document.querySelector("#advanced");
@@ -85,17 +97,35 @@ async function setup() {
 
   eCopySummary.style.display = "none";
 
-  async function handleGetData(response) {
-    if (response.token && eStatus) {
+  const eApiParams = document.querySelectorAll(".api_param");
+  if (!eApiParams.length) {
+    console.error("Could not find api param divs");
+    return;
+  }
+
+  eApiParams.forEach((element) => {
+    element.style.display = 'none';
+  });
+
+  async function handleGetData({ token, api_token, sync_existing, browser } = {}) {
+    if (token && eStatus) {
       eStatus.classList.remove('status_error');
       eStatus.classList.add('status_good');
 
-      eTokenInput.value = response.token;
+      eTokenInput.value = token;
+      eApiTokenInput.value = api_token;
 
-      if (response.sync_existing)
+      if (sync_existing) {
         setStatus("auto_token");
-      else
+      } else {
         setStatus("manual_token");
+      }
+
+      if (api_token) {
+        eApiParams.forEach((element) => {
+          element.style.display = '';
+        });
+      }
 
       chrome.extension.isAllowedIncognitoAccess()
         .then((isAllowedAccess) => {
@@ -111,7 +141,7 @@ async function setup() {
           eIncognito.style.display = "";
 
           // NOTE: slight little hack to make the chrome://extensions link not be blocked.
-          if (response.browser === "chrome") {
+          if (browser === "chrome") {
             const eChromeLink = document.querySelector("#chrome_link");
             if (eChromeLink) {
               eChromeLink.addEventListener("click", async () => {
@@ -136,17 +166,19 @@ async function setup() {
     // Sometimes the background/popup communication fails, but we can still get local info
     const sessionObject = await chrome.storage.local.get('session_token');
     const syncObject = await chrome.storage.local.get('sync_existing');
+    const apiObject = await chrome.storage.local.get('api_token');
 
     handleGetData({
       token: sessionObject?.session_token,
       sync_existing: typeof syncObject?.sync_existing !== 'undefined' ? syncObject : true,
+      api_token: apiObject?.api_token,
       browser: "chrome",
     });
   }
 
   const eSaveToken = document.querySelector("#token_save");
   if (!eSaveToken) {
-    console.error("Could not find save token button");
+    console.error("Could not find save tokens button");
     return;
   }
 
@@ -166,7 +198,17 @@ async function setup() {
       if (token) eToken.value = token;
     }
 
-    chrome.runtime.sendMessage({ type: "save_token", token: token }, (response) => {
+    const eApiToken = document.querySelector("#api_token_input");
+    if (!eApiToken) {
+      console.error("No API token input found.");
+      return;
+    }
+
+    const api_token = eApiToken.value;
+
+    eSaveToken.innerText = 'Saving...';
+
+    chrome.runtime.sendMessage({ type: "save_token", token, api_token }, (response) => {
       if (!response)
         console.error('error saving token: ', chrome.runtime.lastError.message);
     });
@@ -199,6 +241,18 @@ async function setup() {
       return;
     }
 
+    const eEngine = document.querySelector("#engine");
+    if (!eEngine) {
+      console.error("No engine select found.");
+      return;
+    }
+
+    const eApiToken = document.querySelector("#api_token_input");
+    if (!eApiToken) {
+      console.error("No API token input found.");
+      return;
+    }
+
     chrome.tabs.query({ active: true }, (tabs) => {
       // Chrome might give us more than one active tab when something like "chrome://*" is also open
       const tab = tabs.find((tab) => tab.url.startsWith('http://') || tab.url.startsWith('https://')) || tabs[0];
@@ -211,7 +265,7 @@ async function setup() {
       eCopySummary.style.display = "none";
       summaryTextContents = '';
 
-      chrome.runtime.sendMessage({ type: "summarize_page", url, summary_type: eSummaryType.value, target_language: eTargetLanguage.value }, (response) => {
+      chrome.runtime.sendMessage({ type: "summarize_page", url, summary_type: eSummaryType.value, target_language: eTargetLanguage.value, token: eTokenInput.value, api_token: eApiToken.value, engine: eEngine.value }, (response) => {
         if (!response)
           console.error('error summarizing: ', chrome.runtime.lastError.message);
       });
@@ -241,7 +295,16 @@ async function setup() {
       setStatus("manual_token");
       eStatus.classList.add('status_good');
       eStatus.classList.remove('status_error');
-      eSummarize.style.display = "";
+      eSaveToken.innerText = 'Set Tokens';
+      if (data.api_token) {
+        eApiParams.forEach((element) => {
+          element.style.display = '';
+        });
+      } else {
+        eApiParams.forEach((element) => {
+          element.style.display = 'none';
+        });
+      }
     } else if (data.type === "reset") {
       setStatus("no_session");
       eStatus.classList.remove('status_good');

--- a/chrome/src/popup.js
+++ b/chrome/src/popup.js
@@ -296,6 +296,13 @@ async function setup() {
       eStatus.classList.add('status_good');
       eStatus.classList.remove('status_error');
       eSaveToken.innerText = 'Set Tokens';
+      
+      if (data.token) {
+        eSummarize.style.display = '';
+      } else {
+        eSummarize.style.display = 'none';
+      }
+
       if (data.api_token) {
         eApiParams.forEach((element) => {
           element.style.display = '';


### PR DESCRIPTION
This adds the option to set/store an API Key, which enables the Engine select/choice.

It's currently only working for Chrome, pending approval, to be ported to Firefox too.

---

[kagi_chrome_0.3.zip](https://github.com/kagisearch/browser_extensions/files/11835145/kagi_chrome_0.3.zip)

---

![0 - no api key](https://github.com/kagisearch/browser_extensions/assets/1239616/3ff32e3a-1911-4f18-bebe-de90c4123313)

![1 - regular summary](https://github.com/kagisearch/browser_extensions/assets/1239616/9620ad7e-69d7-448c-8d60-c45f6e1c4181)

![2 - with api key](https://github.com/kagisearch/browser_extensions/assets/1239616/21aea6f0-748f-40b8-8f09-2e60757b48d7)

![3 - main view with api key](https://github.com/kagisearch/browser_extensions/assets/1239616/aebd4c7d-0e21-483b-b21a-f19515ef1c58)

![4 - muriel summary](https://github.com/kagisearch/browser_extensions/assets/1239616/5e2ca3ea-03bb-4eeb-a73f-3829a2c2f019)
