### PR TITLE
Reduce scope of permissions request in Firefox manifest

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -25,7 +25,7 @@
     "storage",
     "tabs"
   ],
-  "host_permissions": ["https://kagi.com/"],
+  "host_permissions": ["https://kagi.com/*"],
   "chrome_settings_overrides": {
     "search_provider": {
       "name": "Kagi",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -25,7 +25,7 @@
     "cookies",
     "storage"
   ],
-  "host_permissions": ["https://kagi.com/"],
+  "host_permissions": ["https://kagi.com/*"],
   "chrome_settings_overrides": {
     "search_provider": {
       "name": "Kagi",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -18,12 +18,12 @@
     "default_popup": "src/popup.html"
   },
   "permissions": [
-    "declarativeNetRequest",
+    "activeTab",
+    "declarativeNetRequestWithHostAccess",
     "webRequest",
     "webRequestBlocking",
     "cookies",
-    "storage",
-    "tabs"
+    "storage"
   ],
   "host_permissions": ["https://kagi.com/"],
   "chrome_settings_overrides": {

--- a/shared/src/background.js
+++ b/shared/src/background.js
@@ -89,7 +89,7 @@ async function updateRules() {
           ],
         },
         condition: {
-          urlFilter: '||kagi.com/',
+          urlFilter: '|https://kagi.com/*',
           resourceTypes: ['main_frame'],
         },
       },


### PR DESCRIPTION
With this change, installing the extension in Firefox no longer results in *any* scary install-time or upgrade-time permissions requests. (But see #14 for the separate issue where onboarding with fresh installs is broken - with or without this change.)

To test this, follow the [Test permissions requests](https://extensionworkshop.com/documentation/develop/test-permission-requests/#observe-or-verify-install-time-permission-requests) instructions. TL;DR: Install [Firefox Developer Edition](https://www.mozilla.org/firefox/developer/), set `xpinstall.signatures.required` to `false` in about:config, rename the built extension from `.zip` to `.xpi`, and use the "Install Add-On From File…" option in the Firefox Extensions panel.
 
**Block content on any page**

This turned out to be the `declarativeNetRequest` permission. Since [the only use of the declarativeNetRequest api](https://github.com/kagisearch/browser_extensions/blob/c6c095ff5b7f0cd4590b3676428121074998c6df/shared/src/background.js#L76) is on the kagi.com domain, which is already in the manifest, the `declarativeNetRequestWithHostAccess` permission can be used instead.

I have made some minor changes to the `host_permissions` match pattern and the declarativeNetRequest api `urlFilter` to ensure that they match, to avoid potential permissions issues. This change also fixes a problem where the extension might have leaked the `Authorization` header in plaintext if someone somehow navigated to kagi.com via 'http'. I don't believe this is a significant security issue, because kagi.com sets a long duration HSTS header, and the user must have navigated to the site at least once to log in before the extension will activate.

**Access browser tabs**

The universal summarizer feature doesn't actually require access to all tabs. It's activated only via a keyboard shortcut or clicking the extension icon. With the `activeTab` permission, those actions automatically grant temporary access to currently active tab in the window that the extension was opened in.

Note that I wasn't actually able to test this, because I do not currently have - or want to have - access to the universal summarizer feature. But it does at least run up to the point where it returns an "Invalid Token!" error.

Fixes #13