### PR TITLE
Popup UX issues in 0.3

### DIFF
--- a/shared/src/background.js
+++ b/shared/src/background.js
@@ -43,14 +43,12 @@ async function saveToken(
   await updateRules();
 
   // tell the extension popup to update the UI
-  if (!shouldSync && sessionToken) {
-    await browser.runtime.sendMessage({
-      type: 'synced',
-      token: sessionToken,
-      api_token: sessionApiToken,
-      api_engine: sessionApiEngine,
-    });
-  }
+  await browser.runtime.sendMessage({
+    type: 'synced',
+    token: sessionToken,
+    api_token: sessionApiToken,
+    api_engine: sessionApiEngine,
+  });
 }
 
 async function summarizePage(options) {

--- a/shared/src/popup.css
+++ b/shared/src/popup.css
@@ -114,6 +114,7 @@ input[type="password"]:focus {
   height: 36px;
 }
 
+#status_permission_message,
 #status_error_message {
   color: #fd6820;
 }

--- a/shared/src/popup.html
+++ b/shared/src/popup.html
@@ -81,7 +81,7 @@
       <span id="status_error_message" style="display: none">
         No kagi session found.<br />
         Login to Kagi or open a Kagi tab and the extension should automatically configure.<br />
-        <a href="https://kagi.com" target="_blank" rel="noopener noreferrer">Let's go!</a>
+        <a id="open_kagi" href="https://kagi.com" target="_blank" rel="noopener noreferrer">Let's go!</a>
       </span>
 
       <span id="status_loading_message">

--- a/shared/src/popup.html
+++ b/shared/src/popup.html
@@ -82,6 +82,9 @@
         No kagi session found.<br />
         Login to Kagi or open a Kagi tab and the extension should automatically configure.<br />
         <a id="open_kagi" href="https://kagi.com" target="_blank" rel="noopener noreferrer">Let's go!</a>
+        <span id="status_permission_message" style="display: none">
+          To automatically configure the extension, please allow access to kagi.com.
+        </span>
       </span>
 
       <span id="status_loading_message">

--- a/shared/src/popup.js
+++ b/shared/src/popup.js
@@ -292,7 +292,10 @@ async function setup() {
   } = {}) {
     if (token) {
       eTokenInput.value = token;
-      eApiTokenInput.value = api_token;
+
+      if (api_token) {
+        eApiTokenInput.value = api_token;
+      }
 
       eSummarize.style.display = '';
 

--- a/shared/src/popup.js
+++ b/shared/src/popup.js
@@ -30,6 +30,21 @@ function setStatus(type) {
 
   switch (type) {
     case 'no_session': {
+      const openKagiElement = document.querySelector('#open_kagi');
+      const permission = {
+        origins: ['https://kagi.com/*'],
+      };
+      browser.permissions.contains(permission).then((hasPermission) => {
+        openKagiElement.onclick = async (e) => {
+          e.preventDefault();
+          const grant = await browser.permissions.request(permission);
+          if (grant) {
+            browser.tabs.create({
+              url: 'https://kagi.com/',
+            });
+          }
+        };
+      });
       statusErrorMessageElement.style.display = '';
       statusErrorIcon.style.display = '';
       statusGoodIcon.style.display = 'none';

--- a/shared/src/popup.js
+++ b/shared/src/popup.js
@@ -209,12 +209,12 @@ async function setup() {
     });
   });
 
-  eAdvanced.addEventListener('click', async () => {
+  function toggleAdvancedDisplay(forceState) {
     const icons = eAdvanced.querySelectorAll('svg');
     const showSettingsIcon = icons[0];
     const closeSettingsIcon = icons[1];
 
-    if (eTokenDiv.style.display === '') {
+    if (forceState === 'close' || eTokenDiv.style.display === '') {
       showSettingsIcon.style.display = '';
       closeSettingsIcon.style.display = 'none';
       eTokenDiv.style.display = 'none';
@@ -231,7 +231,8 @@ async function setup() {
       eCopySummary.style.display = 'none';
       eAdvanced.setAttribute('title', 'Close advanced settings');
     }
-  });
+  }
+  eAdvanced.addEventListener('click', () => toggleAdvancedDisplay());
 
   eSummarizePage.addEventListener('click', async () => {
     const eSummaryType = document.querySelector('#summary_type');
@@ -425,6 +426,7 @@ async function setup() {
       setStatus('no_session');
       eTokenDiv.style.display = 'none';
       eAdvanced.style.display = '';
+      toggleAdvancedDisplay('close');
     } else if (data.type === 'summary_finished') {
       if (data.success) {
         eSummaryResult.classList.remove('error');

--- a/shared/src/popup.js
+++ b/shared/src/popup.js
@@ -375,20 +375,24 @@ async function setup() {
     }
   }
 
-  const sessionObject = await browser.storage.local.get('session_token');
-  const syncObject = await browser.storage.local.get('sync_existing');
-  const apiObject = await browser.storage.local.get('api_token');
-  const apiEngineObject = await browser.storage.local.get('api_engine');
+  async function updateSettings() {
+    const sessionObject = await browser.storage.local.get('session_token');
+    const syncObject = await browser.storage.local.get('sync_existing');
+    const apiObject = await browser.storage.local.get('api_token');
+    const apiEngineObject = await browser.storage.local.get('api_engine');
 
-  await handleGetData({
-    token: sessionObject?.session_token,
-    sync_existing:
-      typeof syncObject?.sync_existing !== 'undefined'
-        ? syncObject.sync_existing
-        : true,
-    api_token: apiObject?.api_token,
-    api_engine: apiEngineObject?.api_engine,
-  });
+    await handleGetData({
+      token: sessionObject?.session_token,
+      sync_existing:
+        typeof syncObject?.sync_existing !== 'undefined'
+          ? syncObject.sync_existing
+          : true,
+      api_token: apiObject?.api_token,
+      api_engine: apiEngineObject?.api_engine,
+    });
+  }
+
+  await updateSettings();
 
   let savingButtonTextTimeout = undefined;
 
@@ -396,6 +400,8 @@ async function setup() {
     if (data.type === 'synced') {
       setStatus('manual_token');
       eSaveToken.innerText = 'Saved!';
+
+      await updateSettings();
 
       if (savingButtonTextTimeout) {
         clearTimeout(savingButtonTextTimeout);

--- a/shared/src/popup.js
+++ b/shared/src/popup.js
@@ -12,6 +12,9 @@ if (typeof browser.runtime.getBrowserInfo === 'function') {
 
 function setStatus(type) {
   const statusElement = document.querySelector('#status');
+  const statusPermissionMessageElement = document.querySelector(
+    '#status_permission_message',
+  );
   const statusErrorMessageElement = document.querySelector(
     '#status_error_message',
   );
@@ -42,6 +45,8 @@ function setStatus(type) {
             browser.tabs.create({
               url: 'https://kagi.com/',
             });
+          } else {
+            statusPermissionMessageElement.style.display = '';
           }
         };
       });


### PR DESCRIPTION
With today's update release, I've found a number of issues with the UI:

- If `api_token` is missing from local storage, the api token field gets set to the literal value `'undefined'`, thus resulting in summary requests failing, even when the user was authed with a Kagi session.
- With the update to manifest v3, the `host_permissions` for https://kagi.com were not guaranteed to be granted on install. That's causing the automatic session retrieval to fail, as the `webRequest` handler is never triggered. (fixes #14)
- When the session is automatically retrieved after clicking `Let's go!`, the popup does not reflect that unless closed and re-opened manually.
- Clearing the session token field causes the popup to reset back to the `no_session` view, but the settings icon remains set to the close button, resulting in a confusing two X's:
  ![image](https://github.com/kagisearch/browser_extensions/assets/12853597/4730a4c2-ff7f-46e8-aa57-47438a0e15bc)

I've addressed all of these in this PR. I hope this will make for a smoother onboarding experience for users :)