### PR TITLE
Fix summarize in incognito windows

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Kagi Search for Chrome",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A simple extension for setting Kagi as a default search engine, and automatically logging in to Kagi in incognito browsing windows",
   "background": {
     "service_worker": "src/background.js",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Kagi Search for Firefox",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A simple helper extension for setting Kagi as a default search engine, and automatically logging in to Kagi in incognito browsing windows.",
   "background": {
     "page": "src/background_page.html"

--- a/shared/src/popup.js
+++ b/shared/src/popup.js
@@ -250,8 +250,14 @@ async function setup() {
     const tab =
       tabs.find(
         (tab) =>
-          tab.url.startsWith('http://') || tab.url.startsWith('https://'),
+          tab?.url?.startsWith('http://') || tab?.url?.startsWith('https://'),
       ) || tabs[0];
+
+    if (!tab) {
+      console.error('No tab/url found.');
+      console.error(tabs);
+      return;
+    }
 
     const { url } = tab;
 

--- a/shared/src/summarize_result.js
+++ b/shared/src/summarize_result.js
@@ -81,10 +81,14 @@ async function setup() {
       const tab =
         tabs.find(
           (tab) =>
-            tab.url.startsWith('http://') || tab.url.startsWith('https://'),
+            tab?.url?.startsWith('http://') || tab?.url?.startsWith('https://'),
         ) || tabs[0];
 
-      const { url } = tab;
+      if (!tab) {
+        console.error('No tab/url found.');
+        console.error(tabs);
+        return;
+      }
 
       searchParams.set('url', url);
 


### PR DESCRIPTION
Basically it seems there's some undocumented `null | undefined` tab being sent when using the extension in incognito mode, and that breaks the code. This was tested in Chrome, can't test in Firefox incognito for now.

---

[kagi_chrome_0.3.5.zip](https://github.com/kagisearch/browser_extensions/files/12197174/kagi_chrome_0.3.5.zip)

[kagi_firefox_0.3.5.zip](https://github.com/kagisearch/browser_extensions/files/12197175/kagi_firefox_0.3.5.zip)
