### PR TITLE
Replacing tabs permission to allow Microsoft Edge to work correctly

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -23,6 +23,7 @@
     "cookies",
     "declarativeNetRequestWithHostAccess",
     "webRequest",
+    "tabs",
     "storage"
   ],
   "host_permissions": ["https://kagi.com/*"],


### PR DESCRIPTION
The 'activeTab' permission is not sufficient to allow Microsoft Edge to query the tabs for their URLs.  'tabs' was removed in an earlier PR to make the Chrome manifest permissions match the Firefox ones.