### PR TITLE
Use chrome.tabs.query instead of browser.tabs.query and limit to curr…

### DIFF
--- a/shared/src/popup.js
+++ b/shared/src/popup.js
@@ -244,7 +244,7 @@ async function setup() {
       return;
     }
 
-    const tabs = await browser.tabs.query({ active: true });
+    const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
 
     // Chrome/Firefox might give us more than one active tab when something like "chrome://*" or "about:*" is also open
     const tab =


### PR DESCRIPTION
…ent window

This change was made to allow Microsoft Edge to work, but it might have the added benefit of allowing us to remove the nearby check for getting more than one active tab.