### PR TITLE
Firefox for Android Tweaks

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Kagi Search for Chrome",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "A simple extension for setting Kagi as a default search engine, and automatically logging in to Kagi in incognito browsing windows",
   "background": {
     "service_worker": "src/background.js",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Kagi Search for Firefox",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "A simple helper extension for setting Kagi as a default search engine, and automatically logging in to Kagi in incognito browsing windows.",
   "background": {
     "page": "src/background_page.html"

--- a/shared/src/background.js
+++ b/shared/src/background.js
@@ -154,7 +154,7 @@ browser.runtime.onMessage.addListener(async (data) => {
   }
 });
 
-browser.commands.onCommand.addListener(async (command) => {
+browser.commands?.onCommand.addListener(async (command) => {
   if (command === 'summarize-active-page') {
     await browser.windows.create({
       url: browser.runtime.getURL('src/summarize_result.html'),

--- a/shared/src/background_page.html
+++ b/shared/src/background_page.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <script type="module" src="background.js"></script>
   </head>
 </html>

--- a/shared/src/popup.css
+++ b/shared/src/popup.css
@@ -1,6 +1,7 @@
 html,
 body {
-  width: 500px;
+  margin: 0;
+  padding: 0;
   background-color: transparent;
   font-family: Arial, Helvetica, sans-serif;
   line-height: 16px;
@@ -18,7 +19,7 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: 483px;
+  width: 500px;
 }
 
 #token {

--- a/shared/src/popup.html
+++ b/shared/src/popup.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="popup.css">
   </head>
 

--- a/shared/src/popup.js
+++ b/shared/src/popup.js
@@ -306,10 +306,26 @@ async function setup() {
     window.close();
   }
 
-  requestPermissionsButton.addEventListener(
-    'click',
-    handleRequestPermissionsButtonClick,
-  );
+  const platformInfo = await browser.runtime.getPlatformInfo();
+  const browserInfo =
+    typeof browser.runtime.getBrowserInfo === 'function' &&
+    (await browser.runtime.getBrowserInfo());
+
+  // Note, _hoping_ by 119 this works, but there's no guarantee.
+  if (
+    platformInfo.os === 'android' &&
+    browserInfo?.version &&
+    parseInt(browserInfo.version, 10) <= 118
+  ) {
+    requestPermissionsButton.addEventListener('click', () => {
+      alert('Cannot request activeTab permission on Android yet.');
+    });
+  } else {
+    requestPermissionsButton.addEventListener(
+      'click',
+      handleRequestPermissionsButtonClick,
+    );
+  }
 
   async function handleGetData({
     token,

--- a/shared/src/summarize_result.html
+++ b/shared/src/summarize_result.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="summarize_result.css">
   </head>
 


### PR DESCRIPTION
Related to #3

Basically, I've confirmed that none of the pieces of functionality we use are currently available in Firefox for Android 118a01 (Nightly). I did, however, make it so that we show the extension popup more nicely, and a different message so there's no visual indication the extension doesn't work.

- The search engine option doesn't show up, as the manifest indicator isn't recognized.
- The incognito session doesn't work, as we can't inject the token into the request headers
- The summarizer doesn't work since we'd need access to the active tab.

When requesting the permission, the error that comes up is the same as mentioned in https://stackoverflow.com/questions/49051084/firefox-console-error-webextension-context-not-found which seems to still be unresolved in https://bugzilla.mozilla.org/show_bug.cgi?id=1447806

Given https://blog.mozilla.org/addons/2023/08/10/prepare-your-firefox-desktop-extension-for-the-upcoming-android-release/ I'd expect we can revisit this in a couple of months and hopefully have some more of the extension working, but for now, it just looks better.

I also made some tweaks for Firefox (desktop) and Chrome, as I was testing everything, for UI consistency.

---

[kagi_chrome_0.3.7.zip](https://github.com/kagisearch/browser_extensions/files/12378542/kagi_chrome_0.3.7.zip)

[kagi_firefox_0.3.7.zip](https://github.com/kagisearch/browser_extensions/files/12378544/kagi_firefox_0.3.7.zip)

---

![Screenshot_20230818-110013](https://github.com/kagisearch/browser_extensions/assets/1239616/2a7fa4b1-5fbc-4d5c-ad42-9322783811f5)

![Screenshot_20230818-110020](https://github.com/kagisearch/browser_extensions/assets/1239616/a4644276-8ced-46ae-8200-13ffb308568e)

![Screenshot_20230818-110028](https://github.com/kagisearch/browser_extensions/assets/1239616/4d5f3abf-8506-443d-8056-dc2def8b2830)

Note this last screenshot isn't "final" (I changed the message later, forgot to take another screenshot).