### PR TITLE
Fix summarize concurrency

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -30,7 +30,7 @@
     "search_provider": {
       "name": "Kagi",
       "search_url": "https://kagi.com/search?q={searchTerms}",
-      "favicon_url": "https://kagi.com/favicon.ico",
+      "favicon_url": "https://assets.kagi.com/v2/favicon-32x32.png",
       "keyword": "@kagi",
       "is_default": true,
       "suggest_url": "https://kagi.com/api/autosuggest?q={searchTerms}",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Kagi Search for Chrome",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "A simple extension for setting Kagi as a default search engine, and automatically logging in to Kagi in incognito browsing windows",
   "background": {
     "service_worker": "src/background.js",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -29,7 +29,7 @@
     "search_provider": {
       "name": "Kagi",
       "search_url": "https://kagi.com/search?q={searchTerms}",
-      "favicon_url": "icons/icon_32px.png",
+      "favicon_url": "https://assets.kagi.com/v2/favicon-32x32.png",
       "keyword": "@kagi",
       "is_default": true,
       "suggest_url": "https://kagi.com/api/autosuggest?q={searchTerms}",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Kagi Search for Firefox",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "A simple helper extension for setting Kagi as a default search engine, and automatically logging in to Kagi in incognito browsing windows.",
   "background": {
     "page": "src/background_page.html"

--- a/shared/src/background.js
+++ b/shared/src/background.js
@@ -59,6 +59,7 @@ async function summarizePage(options) {
       type: 'summary_finished',
       summary,
       success,
+      url: options.url,
     });
   }
 }

--- a/shared/src/lib/utils.js
+++ b/shared/src/lib/utils.js
@@ -114,11 +114,18 @@ export async function fetchSettings() {
   };
 }
 
-export async function getActiveTab() {
-  const tabs = await browser.tabs.query({
+export async function getActiveTab(fetchingFromShortcut = false) {
+  const tabsQuery = {
     active: true,
     lastFocusedWindow: true,
-  });
+  };
+
+  // Don't look just in the last focused window if we're opening from the shortcut
+  if (fetchingFromShortcut) {
+    tabsQuery.lastFocusedWindow = undefined;
+  }
+
+  const tabs = await browser.tabs.query(tabsQuery);
 
   // Chrome/Firefox might give us more than one active tab when something like "chrome://*" or "about:*" is also open
   const tab =
@@ -129,7 +136,7 @@ export async function getActiveTab() {
 
   if (!tab || !tab.url) {
     console.error('No tab/url found.');
-    console.error(tabs);
+    console.error(JSON.stringify(tabs));
     return null;
   }
 


### PR DESCRIPTION
This fixes the issue reported in https://kagifeedback.org/d/1978-firefox-extension-race-condition-when-summarizing-multiple-pages where many concurrent summarization requests could end up being "overwritten" by more recent requests.

It also fixes a different race condition when opening the summarization via shortcut.

---

[kagi_chrome_0.3.8.zip](https://github.com/kagisearch/browser_extensions/files/12707900/kagi_chrome_0.3.8.zip)

[kagi_firefox_0.3.8.zip](https://github.com/kagisearch/browser_extensions/files/12707901/kagi_firefox_0.3.8.zip)
