### PR TITLE
Fix Firefox search favicon URL

### DIFF
--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -29,7 +29,7 @@
     "search_provider": {
       "name": "Kagi",
       "search_url": "https://kagi.com/search?q={searchTerms}",
-      "favicon_url": "https://assets.kagi.com/v2/favicon-32x32.png",
+      "favicon_url": "icons/icon_32px.png",
       "keyword": "@kagi",
       "is_default": true,
       "suggest_url": "https://kagi.com/api/autosuggest?q={searchTerms}",


### PR DESCRIPTION
Apparently Chrome changed the spec, not Firefox.

---

[kagi_firefox_0.3.8.zip](https://github.com/kagisearch/browser_extensions/files/12739914/kagi_firefox_0.3.8.zip)
