### PR TITLE
Increase version to release v0.4.1

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Kagi Search for Chrome",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A simple extension for setting Kagi as a default search engine, and automatically logging in to Kagi in incognito browsing windows",
   "background": {
     "service_worker": "src/background.js",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Kagi Search for Firefox",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A simple helper extension for setting Kagi as a default search engine, and automatically logging in to Kagi in incognito browsing windows.",
   "background": {
     "page": "src/background_page.html"


### PR DESCRIPTION
It has a fix for image search, merged in #43

---

[kagi_chrome_0.4.1.zip](https://github.com/kagisearch/browser_extensions/files/12916969/kagi_chrome_0.4.1.zip)

[kagi_firefox_0.4.1.zip](https://github.com/kagisearch/browser_extensions/files/12916970/kagi_firefox_0.4.1.zip)
