### PR TITLE
When copy summary, trim and add more space for key moments

### DIFF
--- a/shared/src/summarize_result.js
+++ b/shared/src/summarize_result.js
@@ -36,7 +36,8 @@ async function setup() {
     }
 
     try {
-      await navigator.clipboard.writeText(summaryTextContents);
+      const summaryToCopy = summaryTextContents.trim().replaceAll('\n', '\n\n');
+      await navigator.clipboard.writeText(summaryToCopy);
 
       copySummaryElement.innerText = 'Copied!';
 


### PR DESCRIPTION
Basically, implementing [this suggestion](https://kagifeedback.org/d/2464-text-formatting-and-copy-button-for-summarizer), a small one-line change.

Summary text in the extension shown in paragraphs:
![image](https://github.com/kagisearch/browser_extensions/assets/5086053/dc29dffe-7c23-4100-a678-af474aa62cff)

But when you copy it, an extra empty line is added to the beginning and to the end of the text. Plus, lines are not divided.
Here is an example for [this video](https://www.youtube.com/watch?v=e-6Niw_ZTJo&ab_channel=macdrown) before:

> 
> There has been a "minor nuclear accident" at the Black Mesa facility in New Mexico which has prompted the deployment of 2,000 military personnel to create a 150 mile exclusion zone.
> Over 1,500 employees from over 75 countries work at Black Mesa and world leaders are requesting information on their status.
> The nature of the incident requires transparency from the U.S. government according to other world leaders.
> An unknown satellite was unexpectedly launched from the U.S. in the last 24 hours, prompting speculation of a connection to Black Mesa though the White House denies any link.
> Vice President-elect Dick Cheney is criticizing President Clinton's "tight-lipped" stance and wants the truth and a prompt report on Black Mesa.
> Many are worried the administration is keeping the American people in the dark about a potential major national security threat.
> The White House says their focus is on those in the surrounding areas, not commenting on the military or employees.
> The incident is speculated to be one of the most expensive recovery operations in U.S. history.
> It's seen as just the beginning of what will be a massive aftermath.
> The video is a reconstruction of archival footage from NBC News in New Mexico covering the developing Black Mesa incident.
> 

And this is after my changes:

> There has been a "minor nuclear accident" at the Black Mesa facility in New Mexico which has prompted the deployment of 2,000 military personnel to create a 150 mile exclusion zone.
> 
> Over 1,500 employees from over 75 countries work at Black Mesa and world leaders are requesting information on their status.
> 
> The nature of the incident requires transparency from the U.S. government according to other world leaders.
> 
> An unknown satellite was unexpectedly launched from the U.S. in the last 24 hours, prompting speculation of a connection to Black Mesa though the White House denies any link.
> 
> Vice President-elect Dick Cheney is criticizing President Clinton's "tight-lipped" stance and wants the truth and a prompt report on Black Mesa.
> 
> Many are worried the administration is keeping the American people in the dark about a potential major national security threat.
> 
> The White House says their focus is on those in the surrounding areas, not commenting on the military or employees.
> 
> The incident is speculated to be one of the most expensive recovery operations in U.S. history.
> 
> It's seen as just the beginning of what will be a massive aftermath.
> 
> The video is a reconstruction of archival footage from NBC News in New Mexico covering the developing Black Mesa incident.

