### PR TITLE
Display error message on summary error

### DIFF
--- a/shared/src/summarize_result.js
+++ b/shared/src/summarize_result.js
@@ -65,7 +65,7 @@ async function setup() {
         copySummaryElement.style.display = '';
       } else {
         summaryResultElement.classList.add('error');
-        summaryTextContents = '';
+        summaryTextContents = data.summary;
         copySummaryElement.style.display = 'none';
       }
 


### PR DESCRIPTION
When you summarize a YouTube video, you might get an error if the video is too recently uploaded or too long. But no actual error is displayed when you click the button:
![Screenshot from 2023-12-02 17-03-43](https://github.com/kagisearch/browser_extensions/assets/5086053/79d2dd8c-fbff-4fd1-a2f4-da10fc51c46f)

Just an empty white screen:
![Screenshot from 2023-12-02 17-04-04](https://github.com/kagisearch/browser_extensions/assets/5086053/811e48bb-4966-40bc-87b7-c3342b163321)

Meanwhile, if you follow the URL manually (`https://kagi.com/mother/summary_labs` with `url` param), you get the response: 
```
{
  "output_text": "Sorry, a problem occurred while processing your request. Please try again later.",
  "output_data": {
    "status": "reading"
  },
  "error": true,
  "tokens": 0,
  "type": "final"
}
```

It gets processed and added to the output of this function:
```
const { summary, success } = await summarizeContent(options);
```

More than that, it handles a lot of different errors. And the result gets passed to the result handler, so technically, just need to display it. So, I just made this one-line change. As a result, you get an error message:
![image](https://github.com/kagisearch/browser_extensions/assets/5086053/5e1cea5d-2276-45d2-958a-3bb39caf34bf)

