### PR TITLE
Support reader more in Firefox

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://docs.rome.tools/schemas/12.1.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.4.1/schema.json",
   "organizeImports": {
     "enabled": false
   },
@@ -11,14 +11,15 @@
     "rules": {
       "recommended": true,
       "complexity": {
-        "noExtraBooleanCast": "off"
+        "noExtraBooleanCast": "off",
+        "noForEach": "off"
       }
     }
   },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
-    "indentSize": 2
+    "indentWidth": 2
   },
   "javascript": {
     "formatter": {

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Kagi Search for Chrome",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A simple extension for setting Kagi as a default search engine, and automatically logging in to Kagi in incognito browsing windows",
   "background": {
     "service_worker": "src/background.js",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Kagi Search for Firefox",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A simple helper extension for setting Kagi as a default search engine, and automatically logging in to Kagi in incognito browsing windows.",
   "background": {
     "page": "src/background_page.html"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,44 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@biomejs/biome": "1.4.1",
         "adm-zip": "0.5.10",
-        "nodemon": "3.0.1",
-        "rome": "12.1.3"
+        "nodemon": "3.0.1"
       },
       "engines": {
         "node": "20.x",
         "npm": "10.x"
       }
     },
-    "node_modules/@rometools/cli-darwin-arm64": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/@rometools/cli-darwin-arm64/-/cli-darwin-arm64-12.1.3.tgz",
-      "integrity": "sha512-AmFTUDYjBuEGQp/Wwps+2cqUr+qhR7gyXAUnkL5psCuNCz3807TrUq/ecOoct5MIavGJTH6R4aaSL6+f+VlBEg==",
+    "node_modules/@biomejs/biome": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.4.1.tgz",
+      "integrity": "sha512-JccVAwPbhi37pdxbAGmaOBjUTKEwEjWAhl7rKkVVuXHo4MLASXJ5HR8BTgrImi4/7rTBsGz1tgVD1Kwv1CHGRg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "1.4.1",
+        "@biomejs/cli-darwin-x64": "1.4.1",
+        "@biomejs/cli-linux-arm64": "1.4.1",
+        "@biomejs/cli-linux-x64": "1.4.1",
+        "@biomejs/cli-win32-arm64": "1.4.1",
+        "@biomejs/cli-win32-x64": "1.4.1"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.4.1.tgz",
+      "integrity": "sha512-PZWy2Idndqux38p6AXSDQM2ldRAWi32bvb7bMbTN0ALzpWYMYnxd71ornatumSSJYoNhKmxzDLq+jct7nZJ79w==",
       "cpu": [
         "arm64"
       ],
@@ -29,12 +54,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": ">=14.*"
+      }
     },
-    "node_modules/@rometools/cli-darwin-x64": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/@rometools/cli-darwin-x64/-/cli-darwin-x64-12.1.3.tgz",
-      "integrity": "sha512-k8MbWna8q4LRlb005N2X+JS1UQ+s3ZLBBvwk4fP8TBxlAJXUz17jLLu/Fi+7DTTEmMhM84TWj4FDKW+rNar28g==",
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.4.1.tgz",
+      "integrity": "sha512-soj3BWhnsM1M2JlzR09cibUzG1owJqetwj/Oo7yg0foijo9lNH9XWXZfJBYDKgW/6Fomn+CC2EcUS+hisQzt9g==",
       "cpu": [
         "x64"
       ],
@@ -42,12 +70,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": ">=14.*"
+      }
     },
-    "node_modules/@rometools/cli-linux-arm64": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/@rometools/cli-linux-arm64/-/cli-linux-arm64-12.1.3.tgz",
-      "integrity": "sha512-X/uLhJ2/FNA3nu5TiyeNPqiD3OZoFfNfRvw6a3ut0jEREPvEn72NI7WPijH/gxSz55znfQ7UQ6iM4DZumUknJg==",
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.4.1.tgz",
+      "integrity": "sha512-YIZqfJUg4F+fPsBTXxgD7EU2E5OAYbmYSl/snf4PevwfQCWE/omOFZv+NnIQmjYj9I7ParDgcJvanoA3/kO0JQ==",
       "cpu": [
         "arm64"
       ],
@@ -55,12 +86,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=14.*"
+      }
     },
-    "node_modules/@rometools/cli-linux-x64": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/@rometools/cli-linux-x64/-/cli-linux-x64-12.1.3.tgz",
-      "integrity": "sha512-csP17q1eWiUXx9z6Jr/JJPibkplyKIwiWPYNzvPCGE8pHlKhwZj3YHRuu7Dm/4EOqx0XFIuqqWZUYm9bkIC8xg==",
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.4.1.tgz",
+      "integrity": "sha512-9YOZw3qBd/KUj63A6Hn2zZgzGb2nbESM0qNmeMXgmqinVKM//uc4OgY5TuKITuGjMSvcVxxd4dX1IzYjV9qvNQ==",
       "cpu": [
         "x64"
       ],
@@ -68,12 +102,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=14.*"
+      }
     },
-    "node_modules/@rometools/cli-win32-arm64": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/@rometools/cli-win32-arm64/-/cli-win32-arm64-12.1.3.tgz",
-      "integrity": "sha512-RymHWeod57EBOJY4P636CgUwYA6BQdkQjh56XKk4pLEHO6X1bFyMet2XL7KlHw5qOTalzuzf5jJqUs+vf3jdXQ==",
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.4.1.tgz",
+      "integrity": "sha512-nWQbvkNKxYn/kCQ0yVF8kCaS3VzaGvtFSmItXiMknU4521LDjJ7tNWH12Gol+pIslrCbd4E1LhJa0a3ThRsBVg==",
       "cpu": [
         "arm64"
       ],
@@ -81,12 +118,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "engines": {
+        "node": ">=14.*"
+      }
     },
-    "node_modules/@rometools/cli-win32-x64": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/@rometools/cli-win32-x64/-/cli-win32-x64-12.1.3.tgz",
-      "integrity": "sha512-yHSKYidqJMV9nADqg78GYA+cZ0hS1twANAjiFibQdXj9aGzD+s/IzIFEIi/U/OBLvWYg/SCw0QVozi2vTlKFDQ==",
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.4.1.tgz",
+      "integrity": "sha512-88fR2CQxQ4YLs2BUDuywWYQpUKgU3A3sTezANFc/4LGKQFFLV2yX+F7QAdZVkMHfA+RD9Xg178HomM/6mnTNPA==",
       "cpu": [
         "x64"
       ],
@@ -94,7 +134,10 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "engines": {
+        "node": ">=14.*"
+      }
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -408,27 +451,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/rome": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/rome/-/rome-12.1.3.tgz",
-      "integrity": "sha512-e+ff72hxDpe/t5/Us7YRBVw3PBET7SeczTQNn6tvrWdrCaAw3qOukQQ+tDCkyFtS4yGsnhjrJbm43ctNbz27Yg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "rome": "bin/rome"
-      },
-      "engines": {
-        "node": ">=14.*"
-      },
-      "optionalDependencies": {
-        "@rometools/cli-darwin-arm64": "12.1.3",
-        "@rometools/cli-darwin-x64": "12.1.3",
-        "@rometools/cli-linux-arm64": "12.1.3",
-        "@rometools/cli-linux-x64": "12.1.3",
-        "@rometools/cli-win32-arm64": "12.1.3",
-        "@rometools/cli-win32-x64": "12.1.3"
       }
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "build": "npm run build-firefox && npm run build-chrome",
     "build-firefox": "node build.js firefox",
     "build-chrome": "node build.js chrome",
-    "format": "rome format --write . && rome check --apply .",
-    "lint": "rome check .",
+    "format": "biome format --write . && biome check --apply .",
+    "lint": "biome check .",
     "test": "npm run lint"
   },
   "repository": {
@@ -25,9 +25,9 @@
   },
   "homepage": "https://github.com/kagisearch/browser_extensions#readme",
   "devDependencies": {
+    "@biomejs/biome": "1.4.1",
     "adm-zip": "0.5.10",
-    "nodemon": "3.0.1",
-    "rome": "12.1.3"
+    "nodemon": "3.0.1"
   },
   "engines": {
     "node": "20.x",

--- a/shared/src/lib/utils.js
+++ b/shared/src/lib/utils.js
@@ -103,9 +103,8 @@ export async function fetchSettings() {
   const apiObject = await browser.storage.local.get('api_token');
   const apiEngineObject = await browser.storage.local.get('api_engine');
   const summaryTypeObject = await browser.storage.local.get('summary_type');
-  const targetLanguageObject = await browser.storage.local.get(
-    'target_language',
-  );
+  const targetLanguageObject =
+    await browser.storage.local.get('target_language');
 
   return {
     token: sessionObject?.session_token,
@@ -139,6 +138,11 @@ export async function getActiveTab(fetchingFromShortcut = false) {
       (tab) =>
         tab?.url?.startsWith('http://') || tab?.url?.startsWith('https://'),
     ) || tabs[0];
+
+  if (tab?.url?.startsWith('about:reader?url=')) {
+    const newUrl = new URL(tab.url);
+    tab.url = newUrl.searchParams.get('url');
+  }
 
   if (!tab || !tab.url) {
     console.error('No tab/url found.');

--- a/shared/src/popup.css
+++ b/shared/src/popup.css
@@ -116,7 +116,8 @@ input[type="password"]:focus {
 }
 
 #status_permission_message,
-#status_error_message {
+#status_error_message,
+#save_error {
   color: #fd6820;
 }
 

--- a/shared/src/popup.html
+++ b/shared/src/popup.html
@@ -161,6 +161,17 @@
           </div>
         </div>
 
+        <div class="setting_row" style="display: none" id="save_error">
+          <div>
+            <div class="title">
+              Error saving token!
+            </div>
+            <div class="desc">
+              It seems the extension isn't able to save the token. Please try disabling the "<span>Allow in Incognito</span>" toggle, saving the token, then enabling it again.
+            </div>
+          </div>
+        </div>
+
         <div class="setting_row">
           <button id="token_save">Save settings</button>
         </div>

--- a/shared/src/popup.js
+++ b/shared/src/popup.js
@@ -192,6 +192,12 @@ async function setup() {
     return;
   }
 
+  const saveErrorDiv = document.querySelector('#save_error');
+  if (!saveErrorDiv) {
+    console.error('Could not find save error div');
+    return;
+  }
+
   saveTokenButton.addEventListener('click', async () => {
     let token = tokenInput.value;
 
@@ -445,6 +451,7 @@ async function setup() {
     if (data.type === 'synced') {
       setStatus('manual_token');
       saveTokenButton.innerText = 'Saved!';
+      saveErrorDiv.style.display = 'none';
 
       const newlyFetchedSettings = await fetchSettings();
       await handleGetData(newlyFetchedSettings);
@@ -489,7 +496,27 @@ async function setup() {
       setStatus('no_session');
       tokenDiv.style.display = 'none';
       advancedToggle.style.display = '';
+      saveErrorDiv.style.display = 'none';
       toggleAdvancedDisplay('close');
+    } else if (data.type === 'save-error') {
+      saveTokenButton.innerText = 'Error saving!';
+
+      if (savingButtonTextTimeout) {
+        clearTimeout(savingButtonTextTimeout);
+      }
+
+      savingButtonTextTimeout = setTimeout(() => {
+        saveTokenButton.innerText = 'Save settings';
+      }, 2000);
+
+      if (!IS_CHROME) {
+        const incognitoNameSpan = saveErrorDiv.querySelector('span');
+        if (incognitoNameSpan) {
+          incognitoNameSpan.innerText = 'Run in Private Windows';
+        }
+      }
+
+      saveErrorDiv.style.display = '';
     }
   });
 }


### PR DESCRIPTION
This was a feature request at https://kagifeedback.org/d/2558-summarizer-doesnt-work-when-firefox-reader-mode-is-active

This also updates [`rome` to `biome`](https://biomejs.dev/blog/annoucing-biome/) and adds an inline message/solution for [this error when saving a token](https://kagifeedback.org/d/2206-extension-not-logging-in-to-search-in-ubuntu-firefox-private-window/21).

How it looks with the error in Firefox:

![firefox](https://github.com/kagisearch/browser_extensions/assets/1239616/614544c3-0c42-4b8a-8a70-8258a3c096e6)

And in Chrome the message changes a bit:

![chrome](https://github.com/kagisearch/browser_extensions/assets/1239616/2a3c1598-8138-47f5-909d-db514e59af8a)

---

[kagi_chrome_0.4.3.zip](https://github.com/kagisearch/browser_extensions/files/13588881/kagi_chrome_0.4.3.zip)

[kagi_firefox_0.4.3.zip](https://github.com/kagisearch/browser_extensions/files/13588882/kagi_firefox_0.4.3.zip)
