### PR TITLE
Add FastGPT input and Small Web link - v0.5.0

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -20,7 +20,8 @@
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
-    "indentWidth": 2
+    "indentWidth": 2,
+    "ignore": ["built/", "safari/"]
   },
   "javascript": {
     "formatter": {

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Kagi Search for Chrome",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "A simple extension for setting Kagi as a default search engine, and automatically logging in to Kagi in incognito browsing windows",
   "background": {
     "service_worker": "src/background.js",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Kagi Search for Firefox",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "A simple helper extension for setting Kagi as a default search engine, and automatically logging in to Kagi in incognito browsing windows.",
   "background": {
     "page": "src/background_page.html"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@biomejs/biome": "1.4.1",
+        "@biomejs/biome": "1.5.2",
         "adm-zip": "0.5.10",
-        "nodemon": "3.0.1"
+        "nodemon": "3.0.3"
       },
       "engines": {
         "node": "20.x",
@@ -19,9 +19,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.4.1.tgz",
-      "integrity": "sha512-JccVAwPbhi37pdxbAGmaOBjUTKEwEjWAhl7rKkVVuXHo4MLASXJ5HR8BTgrImi4/7rTBsGz1tgVD1Kwv1CHGRg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.5.2.tgz",
+      "integrity": "sha512-LhycxGQBQLmfv6M3e4tMfn/XKcUWyduDYOlCEBrHXJ2mMth2qzYt1JWypkWp+XmU/7Hl2dKvrP4mZ5W44+nWZw==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -35,18 +35,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "1.4.1",
-        "@biomejs/cli-darwin-x64": "1.4.1",
-        "@biomejs/cli-linux-arm64": "1.4.1",
-        "@biomejs/cli-linux-x64": "1.4.1",
-        "@biomejs/cli-win32-arm64": "1.4.1",
-        "@biomejs/cli-win32-x64": "1.4.1"
+        "@biomejs/cli-darwin-arm64": "1.5.2",
+        "@biomejs/cli-darwin-x64": "1.5.2",
+        "@biomejs/cli-linux-arm64": "1.5.2",
+        "@biomejs/cli-linux-arm64-musl": "1.5.2",
+        "@biomejs/cli-linux-x64": "1.5.2",
+        "@biomejs/cli-linux-x64-musl": "1.5.2",
+        "@biomejs/cli-win32-arm64": "1.5.2",
+        "@biomejs/cli-win32-x64": "1.5.2"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.4.1.tgz",
-      "integrity": "sha512-PZWy2Idndqux38p6AXSDQM2ldRAWi32bvb7bMbTN0ALzpWYMYnxd71ornatumSSJYoNhKmxzDLq+jct7nZJ79w==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-3JVl08aHKsPyf0XL9SEj1lssIMmzOMAn2t1zwZKBiy/mcZdb0vuyMSTM5haMQ/90wEmrkYN7zux777PHEGrGiw==",
       "cpu": [
         "arm64"
       ],
@@ -60,9 +62,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.4.1.tgz",
-      "integrity": "sha512-soj3BWhnsM1M2JlzR09cibUzG1owJqetwj/Oo7yg0foijo9lNH9XWXZfJBYDKgW/6Fomn+CC2EcUS+hisQzt9g==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-QAPW9rZb/AgucUx+ogMg+9eJNipQDqvabktC5Tx4Aqb/mFzS6eDqNP7O0SbGz3DtC5Y2LATEj6o6zKIQ4ZT+3w==",
       "cpu": [
         "x64"
       ],
@@ -76,9 +78,25 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.4.1.tgz",
-      "integrity": "sha512-YIZqfJUg4F+fPsBTXxgD7EU2E5OAYbmYSl/snf4PevwfQCWE/omOFZv+NnIQmjYj9I7ParDgcJvanoA3/kO0JQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-fVLrUgIlo05rO4cNu+Py5EwwmXnXhWH+8KrNlWkr2weMYjq85SihUsuWWKpmqU+bUVR+m5gwfcIXZVWYVCJMHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.*"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.5.2.tgz",
+      "integrity": "sha512-Z29SjaOyO4QfajplNXSjLx17S79oPN42D094zjE24z7C7p3NxvLhKLygtSP9emgaXkcoESe2chOzF4IrGy/rlg==",
       "cpu": [
         "arm64"
       ],
@@ -92,9 +110,25 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.4.1.tgz",
-      "integrity": "sha512-9YOZw3qBd/KUj63A6Hn2zZgzGb2nbESM0qNmeMXgmqinVKM//uc4OgY5TuKITuGjMSvcVxxd4dX1IzYjV9qvNQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.5.2.tgz",
+      "integrity": "sha512-ixqJtUHtF0ho1+1DTZQLAEwHGSqvmvHhAAFXZQoaSdABn+IcITYExlFVA3bGvASy/xtPjRhTx42hVwPtLwMHwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.*"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.5.2.tgz",
+      "integrity": "sha512-ZolquPEjWYUmGeERS8svHOOT7OXEeoriPnV8qptgWJmYF9EO9HUGRn1UtCvdVziDYK+u1A7PxjOdkY1B00ty5A==",
       "cpu": [
         "x64"
       ],
@@ -108,9 +142,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.4.1.tgz",
-      "integrity": "sha512-nWQbvkNKxYn/kCQ0yVF8kCaS3VzaGvtFSmItXiMknU4521LDjJ7tNWH12Gol+pIslrCbd4E1LhJa0a3ThRsBVg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.5.2.tgz",
+      "integrity": "sha512-DN4cXSAoFTdjOoh7f+JITj1uQgQSXt+1pVea9bFrpbgip+ZwkONqQq+jUcmFMMehbp9LuiVtNXFz/ReHn6FY7A==",
       "cpu": [
         "arm64"
       ],
@@ -124,9 +158,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.4.1.tgz",
-      "integrity": "sha512-88fR2CQxQ4YLs2BUDuywWYQpUKgU3A3sTezANFc/4LGKQFFLV2yX+F7QAdZVkMHfA+RD9Xg178HomM/6mnTNPA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.5.2.tgz",
+      "integrity": "sha512-YvWWXZmk936FdrXqc2jcP6rfsXsNBIs9MKBQQoVXIihwNNRiAaBD9Iwa/ouU1b7Zxq2zETgeuRewVJickFuVOw==",
       "cpu": [
         "x64"
       ],
@@ -238,12 +272,20 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/fill-range": {
@@ -366,19 +408,19 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "node_modules/nodemon": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.1.tgz",
-      "integrity": "sha512-g9AZ7HmkhQkqXkRc20w+ZfQ73cHLbE8hnPbtaFbFtCumZsjyMhKk9LajQ07U5Ux28lvFjZ5X7HvWR1xzU8jHVw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.3.tgz",
+      "integrity": "sha512-7jH/NXbFPxVaMwmBCC2B9F/V6X1VkEdNgx3iu9jji8WxWcvhMWkmhNWhI5077zknOnZnBzba9hZP6bCPJLSReQ==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.5.2",
-        "debug": "^3.2.7",
+        "debug": "^4",
         "ignore-by-default": "^1.0.1",
         "minimatch": "^3.1.2",
         "pstree.remy": "^1.1.8",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   },
   "homepage": "https://github.com/kagisearch/browser_extensions#readme",
   "devDependencies": {
-    "@biomejs/biome": "1.4.1",
+    "@biomejs/biome": "1.5.2",
     "adm-zip": "0.5.10",
-    "nodemon": "3.0.1"
+    "nodemon": "3.0.3"
   },
   "engines": {
     "node": "20.x",

--- a/shared/src/popup.css
+++ b/shared/src/popup.css
@@ -36,7 +36,7 @@ input {
   border: 1px solid #e1e0db;
 }
 
-input[type="password"] {
+input[type="password"], input[type="text"] {
   background-color: #f7f6f2;
   border: 1px solid #e1e0db;
   height: 48px;
@@ -44,7 +44,7 @@ input[type="password"] {
   padding: 0 10px;
 }
 
-input[type="password"]:focus {
+input[type="password"]:focus, input[type="text"]:focus {
   outline: 1px solid #ffb319;
 }
 
@@ -60,13 +60,39 @@ input[type="password"]:focus {
 .logo {
   width: 58px;
   height: 29px;
-  flex: 1;
+  flex: 0;
   justify-content: flex-start;
   display: flex;
+  margin: 0 15px;
 }
 
 .logo svg {
   height: 100%;
+}
+
+#links {
+  flex: 1;
+  justify-content: flex-start;
+  display: flex;
+  font-size: 11px;
+  color: rgba(0, 0, 0, 0.6);
+  margin: 0 10px;
+  visibility: hidden;
+}
+
+#links a {
+  display: inline-block;
+  color: rgba(0, 0, 0, 0.6);
+  text-decoration: none;
+}
+
+#links a:hover, #links a:focus {
+  text-decoration: underline;
+}
+
+#links span {
+  display: inline-block;
+  margin: 0 7px;
 }
 
 #status {
@@ -288,20 +314,29 @@ p {
   right: 2px;
 }
 
-#summarize, #request_permissions {
+#fastgpt, #summarize, #request_permissions {
   margin-top: 10px;
   width: 100%;
   padding: 0 15px;
 }
 
-#summarize .setting_row, #request_permissions .setting_row {
+#summarize .setting_row, #request_permissions .setting_row, #fastgpt .setting_row {
   margin-top: 10px;
   padding: 0;
   justify-content: space-between;
 }
 
-#summarize .setting_row > div, #request_permissions .setting_row > div {
+#summarize .setting_row > div, #request_permissions .setting_row > div, #fastgpt .setting_row > form {
   margin-right: 10px;
+}
+
+#fastgpt_form {
+  width: 100%;
+  display: flex;
+}
+
+#fastgpt_form input {
+  margin-right: 10px
 }
 
 #summarize .setting_row label {
@@ -309,7 +344,7 @@ p {
   margin-bottom: 5px;
 }
 
-#summarize_page, #request_permissions_button {
+#summarize_page, #request_permissions_button, #fastgpt_submit {
   background-color: #ffb319;
   border: 1px solid #ffb319;
   color: #191919;
@@ -323,13 +358,18 @@ p {
   margin-right: 10px;
 }
 
+#fastgpt_submit {
+  width: 120px;
+  margin-right: 0;
+}
+
 #request_permissions_button {
   max-width: 400px;
   margin-left: auto;
   margin-right: auto;
 }
 
-#summarize_page:hover, #request_permissions_button:hover {
+#summarize_page:hover, #request_permissions_button:hover, #fastgpt_submit {
   background-color: #f7a808;
   border: 1px solid #d9950d;
 }

--- a/shared/src/popup.html
+++ b/shared/src/popup.html
@@ -18,6 +18,10 @@
             <path d="M100.486 8.93162C102.979 8.93162 105 6.93221 105 4.46581C105 1.99941 102.979 0 100.486 0C97.9936 0 95.9728 1.99941 95.9728 4.46581C95.9728 6.93221 97.9936 8.93162 100.486 8.93162Z" fill="currentColor"></path>
             </svg>
         </div>
+
+        <div id="links">
+          <a href="https://kagi.com/smallweb" target="_blank" rel="noopener noreferrer">Small Web</a>
+        </div>
         
         <span id="status" title="Loading...">
           <svg style="display: none" aria-hidden="true" height="100%" width="100%" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -129,7 +133,7 @@
         </div>
 
         <div class="setting_row">
-          <input type="password" id="token_input" value="" placeholder="my token"/>
+          <input type="password" id="token_input" value="" placeholder="my token" />
         </div>
 
         <div class="setting_row">
@@ -146,7 +150,7 @@
         </div>
 
         <div class="setting_row">
-          <input type="password" id="api_token_input" value="" placeholder="my API key"/>
+          <input type="password" id="api_token_input" value="" placeholder="my API key" />
         </div>
 
         <div class="setting_row api_param" style="display: none">
@@ -176,6 +180,20 @@
           <button id="token_save">Save settings</button>
         </div>
 
+      </div>
+
+      <div id="fastgpt" style="display: none">
+        <div class="title">
+          FastGPT
+        </div>
+
+        <div class="setting_row">
+          <form id="fastgpt_form" action="https://kagi.com/fastgpt?query=" method="GET" target="_blank">
+            <input id="fastgpt_query" name="query" type="text" value="" placeholder="Ask any question..." />
+
+            <button id="fastgpt_submit" type="submit">Answer</button>
+          </form>
+        </div>
       </div>
 
       <div id="summarize" style="display: none">


### PR DESCRIPTION
This implements a FastGPT input and Small Web link (with support for adding more links in the future). Both only show up _after_ having a valid session.

Because of the FastGPT input, if you have a valid session, opening the popup will now automatically focus that input field, so you can start typing right away. Pressing enter opens the FastGPT window with the query prefilled.

Clicking "Small Web" simply opens a new tab with that URL.

This also implements a fail-safe for issues reported in https://kagifeedback.org/d/2234-kagi-extension-api-key-not-persistent-in-firefox-esr-on-kali-linux and https://kagifeedback.org/d/2090-kagi-keeps-saying-invalid-session-token-in-firefox-on-linux-after-setting-up-successfully-and-working-fine-for-a-while and https://kagifeedback.org/d/2748-firefox-default-search-engine-keeps-resetting and hopefully make those easier to self-fix.

Finally, some linter and formatter tweaks and fixes were also added here, and the dependencies updated.

---

![Screenshot from 2024-01-19 15-52-12](https://github.com/kagisearch/browser_extensions/assets/1239616/2417000d-bb6a-49a0-a839-66cb94e79961)

---

[kagi_chrome_0.5.0.zip](https://github.com/kagisearch/browser_extensions/files/13991311/kagi_chrome_0.5.0.zip)

[kagi_firefox_0.5.0.zip](https://github.com/kagisearch/browser_extensions/files/13991312/kagi_firefox_0.5.0.zip)

