### PR TITLE
Fix the Kagi Summarize context menu action for Firefox

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Kagi Search for Chrome",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A simple extension for setting Kagi as a default search engine, and automatically logging in to Kagi in incognito browsing windows",
   "background": {
     "service_worker": "src/background.js",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Kagi Search for Firefox",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A simple helper extension for setting Kagi as a default search engine, and automatically logging in to Kagi in incognito browsing windows.",
   "background": {
     "page": "src/background_page.html"

--- a/shared/src/background.js
+++ b/shared/src/background.js
@@ -278,10 +278,30 @@ browser.contextMenus.create({
 });
 
 // Add a listener for the context menu item.
-browser.contextMenus.onClicked.addListener((info, tab) => {
+browser.contextMenus.onClicked.addListener(async (info, tab) => {
   if (info.menuItemId === 'kagi-summarize') {
+    if (!IS_CHROME) {  // Attach permission request to user input handler for Firefox
+      await requestActiveTabPermission();
+    }
     kagiSummarize(info, tab);
   } else if (info.menuItemId === 'kagi-image-search') {
     kagiImageSearch(info, tab);
   }
 });
+
+// Firefox only - request for activeTab permission must be attached to a user input handler
+async function requestActiveTabPermission() {
+  try {
+    const granted = await browser.permissions.request({
+      permissions: ['activeTab'],
+    });
+    if (!granted) {
+      console.error('Permission not granted for activeTab.');
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.error('Error requesting activeTab permission:', error);
+    return false;
+  }
+}

--- a/shared/src/background.js
+++ b/shared/src/background.js
@@ -1,4 +1,4 @@
-import { summarizeContent, fetchSettings } from './lib/utils.js';
+import { summarizeContent, fetchSettings, requestActiveTabPermission } from './lib/utils.js';
 
 if (!globalThis.browser) {
   globalThis.browser = chrome;
@@ -289,19 +289,3 @@ browser.contextMenus.onClicked.addListener(async (info, tab) => {
   }
 });
 
-// Firefox only - request for activeTab permission must be attached to a user input handler
-async function requestActiveTabPermission() {
-  try {
-    const granted = await browser.permissions.request({
-      permissions: ['activeTab'],
-    });
-    if (!granted) {
-      console.error('Permission not granted for activeTab.');
-      return false;
-    }
-    return true;
-  } catch (error) {
-    console.error('Error requesting activeTab permission:', error);
-    return false;
-  }
-}

--- a/shared/src/lib/utils.js
+++ b/shared/src/lib/utils.js
@@ -161,3 +161,19 @@ export async function getActiveTab(fetchingFromShortcut = false) {
 
   return tab;
 }
+
+export async function requestActiveTabPermission() {
+  try {
+    const granted = await browser.permissions.request({
+      permissions: ['activeTab'],
+    });
+    if (!granted) {
+      console.error('Permission not granted for activeTab.');
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.error('Error requesting activeTab permission:', error);
+    return false;
+  }
+}

--- a/shared/src/popup.js
+++ b/shared/src/popup.js
@@ -1,4 +1,4 @@
-import { fetchSettings, getActiveTab } from './lib/utils.js';
+import { fetchSettings, getActiveTab, requestActiveTabPermission } from './lib/utils.js';
 
 if (!globalThis.browser) {
   globalThis.browser = chrome;
@@ -376,9 +376,7 @@ async function setup() {
     event.preventDefault();
     event.stopPropagation();
 
-    const permissionGranted = await browser.permissions.request({
-      permissions: ['activeTab'],
-    });
+    const permissionGranted = await requestActiveTabPermission();
 
     if (!permissionGranted) {
       alert(


### PR DESCRIPTION
- Update background.js to attach request for activeTab permission to a user input handler, if the browser is not Chrome.
- Increment minor version numbering in manifest.json (Chrome and Firefox)

Addresses [issue #85 ](https://github.com/kagisearch/browser_extensions/issues/85). A request for activeTab optional permission must be attached to a user input handler ([MDN docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission)).