### PR TITLE
Update `chrome_settings_overrides.search_provider.suggest_url` to kagisuggest.com

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -34,7 +34,7 @@
       "favicon_url": "https://assets.kagi.com/v2/favicon-32x32.png",
       "keyword": "@kagi",
       "is_default": true,
-      "suggest_url": "https://kagi.com/api/autosuggest?q={searchTerms}",
+      "suggest_url": "https://kagisuggest.com/api/autosuggest?q={searchTerms}",
       "encoding": "UTF-8"
     }
   },

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -33,7 +33,7 @@
       "favicon_url": "icons/icon_32px.png",
       "keyword": "@kagi",
       "is_default": true,
-      "suggest_url": "https://kagi.com/api/autosuggest?q={searchTerms}",
+      "suggest_url": "https://kagisuggest.com/api/autosuggest?q={searchTerms}",
       "encoding": "UTF-8"
     }
   },


### PR DESCRIPTION
This is mainly to complement use with Privacy Pass, but is functionally a no-op. The main difference is that cookies will not be sent with requests to `kagisuggest.com`

I don't know if this will update the autosuggest configuration for existing users or not, but it's fine in either case.