### PR TITLE
[Firefox] fix session cookie retrieval under First-Party Isolation

### DIFF
--- a/shared/src/background.js
+++ b/shared/src/background.js
@@ -154,10 +154,17 @@ async function checkForSession() {
   if (!syncSessionFromExisting) return;
   if (!sessionPrivacyConsent) return;
 
-  const cookie = await browser.cookies.get({
-    url: 'https://kagi.com',
-    name: 'kagi_session',
-  });
+  const cookie = (
+    await browser.cookies.getAll({
+      url: 'https://kagi.com',
+      name: 'kagi_session',
+      ...(IS_CHROME
+        ? {}
+        : {
+            firstPartyDomain: null,
+          }),
+    })
+  ).at(-1);
 
   if (!cookie || !cookie.value) return;
 


### PR DESCRIPTION
Setup no longer errors when `privacy.firstparty.isolate` is enabled, as is the default in Tor Browser:

```
checkForSession - background.js:165:41
Error: First-Party Isolation is enabled, but the required 'firstPartyDomain' attribute was not set.
```